### PR TITLE
Rename and enhance NetworkHelper methods

### DIFF
--- a/TouchSenderReceiver/Helpers/NetworkHelper.cs
+++ b/TouchSenderReceiver/Helpers/NetworkHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.NetworkInformation;
+﻿using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 
 namespace TouchSenderReceiver.Helpers;
@@ -11,7 +12,7 @@ public class NetworkHelper
     /// </summary>
     /// <param name="networkInterfaceType"></param>
     /// <returns></returns>
-    public static IList<string> GetAllLocalIPv4(NetworkInterfaceType networkInterfaceType = NetworkInterfaceType.Ethernet)
+    public static IList<string> GetAllLocalIPv4ByNIC(NetworkInterfaceType networkInterfaceType = NetworkInterfaceType.Ethernet)
     {
         List<string> ipAddrList = [];
         foreach (NetworkInterface item in NetworkInterface.GetAllNetworkInterfaces())
@@ -28,5 +29,22 @@ public class NetworkHelper
             }
         }
         return ipAddrList;
+    }
+
+    /// <summary>
+    /// Get all local IPv4 addresses of the current machine.
+    /// </summary>
+    public static IEnumerable<string> GetAllLocalIPv4()
+    {
+        string hostname = Dns.GetHostName();
+
+        IPAddress[] adrList = Dns.GetHostAddresses(hostname);
+        foreach (IPAddress address in adrList)
+        {
+            if (address.AddressFamily == AddressFamily.InterNetwork)
+            {
+                yield return address.ToString();
+            }
+        }
     }
 }

--- a/TouchSenderTablet.GUI/ViewModels/MainViewModel.cs
+++ b/TouchSenderTablet.GUI/ViewModels/MainViewModel.cs
@@ -113,7 +113,7 @@ public partial class MainViewModel : ObservableRecipient
         _screenOptions = _touchReceiverSettingsService.ScreenOptions;
 
         var candidateIpAddresses = NetworkHelper.GetAllLocalIPv4().ToList();
-        IpAddresses = candidateIpAddresses.Count > 0 ? string.Join(" / ", NetworkHelper.GetAllLocalIPv4()) : "Unknown".GetLocalized();
+        IpAddresses = candidateIpAddresses.Count > 0 ? string.Join(" / ", candidateIpAddresses) : "Unknown".GetLocalized();
     }
 
     private void SetInitialCanvas()

--- a/TouchSenderTablet.GUI/ViewModels/MainViewModel.cs
+++ b/TouchSenderTablet.GUI/ViewModels/MainViewModel.cs
@@ -112,7 +112,7 @@ public partial class MainViewModel : ObservableRecipient
         _serviceOptions = _touchReceiverSettingsService.ServiceOptions;
         _screenOptions = _touchReceiverSettingsService.ScreenOptions;
 
-        var candidateIpAddresses = NetworkHelper.GetAllLocalIPv4();
+        var candidateIpAddresses = NetworkHelper.GetAllLocalIPv4().ToList();
         IpAddresses = candidateIpAddresses.Count > 0 ? string.Join(" / ", NetworkHelper.GetAllLocalIPv4()) : "Unknown".GetLocalized();
     }
 


### PR DESCRIPTION
## What's new?

- Changed method name from `GetAllLocalIPv4` to `GetAllLocalIPv4ByNIC` in `NetworkHelper.cs` while keeping the default parameter.
- Added a new method `GetAllLocalIPv4` to retrieve local IPv4 addresses of the current machine.
- Updated `MainViewModel.cs` to convert the result of `GetAllLocalIPv4` to a list for improved IP address handling.


