### PR TITLE
Add help page

### DIFF
--- a/TouchSenderTablet.GUI/Services/PageService.cs
+++ b/TouchSenderTablet.GUI/Services/PageService.cs
@@ -16,6 +16,7 @@ public class PageService : IPageService
     {
         Configure<MainViewModel, MainPage>();
         Configure<SettingsViewModel, SettingsPage>();
+        Configure<HelpViewModel, HelpPage>();
     }
 
     public Type GetPageType(string key)

--- a/TouchSenderTablet.GUI/Strings/en-us/Resources.resw
+++ b/TouchSenderTablet.GUI/Strings/en-us/Resources.resw
@@ -123,6 +123,9 @@
   <data name="AppDescription" xml:space="preserve">
     <value>TouchSender Tablet</value>
   </data>
+  <data name="Shell_Help.Content" xml:space="preserve">
+    <value>Help</value>
+  </data>
   <data name="Shell_Main.Content" xml:space="preserve">
     <value>TouchSender Tablet</value>
   </data>
@@ -234,5 +237,21 @@ Note that if this window is in focus while a touch operation is performed, the c
   </data>
   <data name="InvalidDataReceptionErrorMessage" xml:space="preserve">
     <value>Incorrectly formatted data received.Please check the log for details.</value>
+  </data>
+  <data name="Help_NoDataReceive_Title.Text" xml:space="preserve">
+    <value>Unable to Receive Data</value>
+  </data>
+  <data name="Help_NoDataReceive_Body.Text" xml:space="preserve">
+    <value>Please review your firewall settings to ensure the software is not being blocked.
+Go to `Control Panel &gt; System and Security &gt; Windows Defender Firewall &gt; Allowed apps`, and make sure TouchSenderTablet is allowed through the firewall.</value>
+  </data>
+  <data name="Help_MobileApp_Title.Text" xml:space="preserve">
+    <value>Where Can I Find the Sending Application?</value>
+  </data>
+  <data name="Help_MobileApp_Body.Text" xml:space="preserve">
+    <value>Please check the GitHub repository for the TouchSender application.</value>
+  </data>
+  <data name="Help_MobileApp_Link.Content" xml:space="preserve">
+    <value>TouchSender App</value>
   </data>
 </root>

--- a/TouchSenderTablet.GUI/Strings/ja-jp/Resources.resw
+++ b/TouchSenderTablet.GUI/Strings/ja-jp/Resources.resw
@@ -123,6 +123,9 @@
   <data name="AppDescription" xml:space="preserve">
     <value>TouchSender Tablet</value>
   </data>
+  <data name="Shell_Help.Content" xml:space="preserve">
+    <value>ヘルプ</value>
+  </data>
   <data name="Shell_Main.Content" xml:space="preserve">
     <value>TouchSender タブレット</value>
   </data>
@@ -234,5 +237,21 @@
   </data>
   <data name="InvalidDataReceptionErrorMessage" xml:space="preserve">
     <value>不正なフォーマットのデータを受信しました。詳しくはログを確認してください。</value>
+  </data>
+  <data name="Help_NoDataReceive_Title.Text" xml:space="preserve">
+    <value>データを受信できない</value>
+  </data>
+  <data name="Help_NoDataReceive_Body.Text" xml:space="preserve">
+    <value>「コントロール パネル &gt; システムとセキュリティ &gt; Windows Defender ファイアウォール &gt; 許可されたアプリ」に移動し、
+TouchSenderTablet がファイアウォールを通過できるように許可されていることを確認してください。</value>
+  </data>
+  <data name="Help_MobileApp_Title.Text" xml:space="preserve">
+    <value>送信用のアプリはどこにある？</value>
+  </data>
+  <data name="Help_MobileApp_Body.Text" xml:space="preserve">
+    <value>TouchSenderアプリケーションのGitHubリポジトリを確認してください。</value>
+  </data>
+  <data name="Help_MobileApp_Link.Content" xml:space="preserve">
+    <value>TouchSenderアプリ</value>
   </data>
 </root>

--- a/TouchSenderTablet.GUI/TouchSenderTablet.GUI.csproj
+++ b/TouchSenderTablet.GUI/TouchSenderTablet.GUI.csproj
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.1.240916" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.250402" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250310001" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.0" />

--- a/TouchSenderTablet.GUI/ViewModels/HelpViewModel.cs
+++ b/TouchSenderTablet.GUI/ViewModels/HelpViewModel.cs
@@ -1,0 +1,8 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace TouchSenderTablet.GUI.ViewModels;
+
+public partial class HelpViewModel : ObservableRecipient
+{
+
+}

--- a/TouchSenderTablet.GUI/Views/HelpPage.xaml
+++ b/TouchSenderTablet.GUI/Views/HelpPage.xaml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page
+    x:Class="TouchSenderTablet.GUI.Views.HelpPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:TouchSenderTablet.GUI.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="using:CommunityToolkit.WinUI"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <x:Double x:Key="SectionSpacing">20</x:Double>
+        <x:Double x:Key="SectionItemSpacing">8</x:Double>
+        <x:Double x:Key="SectionTitleSpacing">12</x:Double>
+        <x:Double x:Key="SectionTitleFontSize">22</x:Double>
+    </Page.Resources>
+
+    <StackPanel Margin="0,12,0,0" Spacing="{StaticResource SectionSpacing}">
+        <StackPanel Spacing="{StaticResource SectionItemSpacing}">
+            <StackPanel Orientation="Horizontal" Spacing="{StaticResource SectionTitleSpacing}">
+                <FontIcon Glyph="&#xF384;" />
+                <TextBlock x:Uid="Help_NoDataReceive_Title" FontSize="{StaticResource SectionTitleFontSize}" />
+            </StackPanel>
+            <TextBlock
+                x:Uid="Help_NoDataReceive_Body"
+                LineHeight="20"
+                TextWrapping="WrapWholeWords" />
+        </StackPanel>
+        <StackPanel Spacing="{StaticResource SectionItemSpacing}">
+            <StackPanel Orientation="Horizontal" Spacing="{StaticResource SectionTitleSpacing}">
+                <FontIcon Glyph="&#xEC64;" />
+                <TextBlock x:Uid="Help_MobileApp_Title" FontSize="{StaticResource SectionTitleFontSize}" />
+            </StackPanel>
+            <StackPanel>
+                <TextBlock x:Uid="Help_MobileApp_Body" />
+                <HyperlinkButton
+                    x:Uid="Help_MobileApp_Link"
+                    Padding="4"
+                    NavigateUri="https://github.com/voltaney/flutter-touch-sender" />
+            </StackPanel>
+        </StackPanel>
+    </StackPanel>
+</Page>

--- a/TouchSenderTablet.GUI/Views/HelpPage.xaml.cs
+++ b/TouchSenderTablet.GUI/Views/HelpPage.xaml.cs
@@ -1,0 +1,11 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace TouchSenderTablet.GUI.Views;
+
+public sealed partial class HelpPage : Page
+{
+    public HelpPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/TouchSenderTablet.GUI/Views/ShellPage.xaml
+++ b/TouchSenderTablet.GUI/Views/ShellPage.xaml
@@ -53,6 +53,11 @@
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xEBFC;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
+                <NavigationViewItem x:Uid="Shell_Help" helpers:NavigationHelper.NavigateTo="TouchSenderTablet.GUI.ViewModels.HelpViewModel">
+                    <NavigationViewItem.Icon>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE897;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
             </NavigationView.MenuItems>
             <NavigationView.HeaderTemplate>
                 <DataTemplate>


### PR DESCRIPTION
This pull request introduces a new **Help section** to the TouchSenderTablet application, including updates to the navigation, resources, and localization files. The most important changes are detailed below:

### New Help Section Implementation:
* Added `HelpViewModel` class to manage the Help section's data and logic. (`TouchSenderTablet.GUI/ViewModels/HelpViewModel.cs`)
* Created `HelpPage` view with XAML layout to display Help content. (`TouchSenderTablet.GUI/Views/HelpPage.xaml`)
* Added code-behind for `HelpPage` to initialize the component. (`TouchSenderTablet.GUI/Views/HelpPage.xaml.cs`)
* Updated `PageService` to include the new Help page configuration. (`TouchSenderTablet.GUI/Services/PageService.cs`)

### Navigation and Localization Updates:
* Added Help navigation item to `ShellPage` for accessing the Help section. (`TouchSenderTablet.GUI/Views/ShellPage.xaml`)
* Updated English and Japanese resource files to include Help section strings and content. (`TouchSenderTablet.GUI/Strings/en-us/Resources.resw`, `TouchSenderTablet.GUI/Strings/ja-jp/Resources.resw`)

### Dependency Update:
* Upgraded `CommunityToolkit.WinUI.Controls.SettingsControls` package to version 8.2.250402. (`TouchSenderTablet.GUI/TouchSenderTablet.GUI.csproj`)