### PR TITLE
Add repository info to SettingPage

### DIFF
--- a/TouchSenderTablet.GUI/Strings/en-us/Resources.resw
+++ b/TouchSenderTablet.GUI/Strings/en-us/Resources.resw
@@ -144,6 +144,12 @@
   <data name="Settings_About.Text" xml:space="preserve">
     <value>About</value>
   </data>
+  <data name="Settings_About_GitHubRepository.Header" xml:space="preserve">
+    <value>GitHub Repository</value>
+  </data>
+  <data name="Settings_About_GitHubIssues.Header" xml:space="preserve">
+    <value>Report a bug or send feedback</value>
+  </data>
   <data name="Settings_AboutDescription.Text" xml:space="preserve">
     <value>TODO: Replace with your app description.</value>
   </data>

--- a/TouchSenderTablet.GUI/Strings/ja-jp/Resources.resw
+++ b/TouchSenderTablet.GUI/Strings/ja-jp/Resources.resw
@@ -148,7 +148,7 @@
     <value>GitHubリポジトリ</value>
   </data>
   <data name="Settings_About_GitHubIssues.Header" xml:space="preserve">
-    <value>バグまたはフィードバックの送信</value>
+    <value>バグ報告またはフィードバックの送信</value>
   </data>
   <data name="Settings_AboutDescription.Text" xml:space="preserve">
     <value>TODO: Replace with your app description.</value>

--- a/TouchSenderTablet.GUI/Strings/ja-jp/Resources.resw
+++ b/TouchSenderTablet.GUI/Strings/ja-jp/Resources.resw
@@ -144,6 +144,12 @@
   <data name="Settings_About.Text" xml:space="preserve">
     <value>About</value>
   </data>
+  <data name="Settings_About_GitHubRepository.Header" xml:space="preserve">
+    <value>GitHubリポジトリ</value>
+  </data>
+  <data name="Settings_About_GitHubIssues.Header" xml:space="preserve">
+    <value>バグまたはフィードバックの送信</value>
+  </data>
   <data name="Settings_AboutDescription.Text" xml:space="preserve">
     <value>TODO: Replace with your app description.</value>
   </data>

--- a/TouchSenderTablet.GUI/Views/SettingsPage.xaml
+++ b/TouchSenderTablet.GUI/Views/SettingsPage.xaml
@@ -51,6 +51,20 @@
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             IsTextSelectionEnabled="True"
                             Text="{x:Bind ViewModel.Version}" />
+                        <toolkit:SettingsExpander.Items>
+                            <toolkit:SettingsCard
+                                x:Name="GitHubRepositorySettingsCard"
+                                x:Uid="Settings_About_GitHubRepository"
+                                ActionIcon="{ui:FontIcon Glyph=&#xE8A7;}"
+                                Click="GitHubRepositorySettingsCard_Click"
+                                IsClickEnabled="True" />
+                            <toolkit:SettingsCard
+                                x:Name="GitHubIssuesSettingsCard"
+                                x:Uid="Settings_About_GitHubIssues"
+                                ActionIcon="{ui:FontIcon Glyph=&#xE8A7;}"
+                                Click="GitHubIssuesSettingsCard_Click"
+                                IsClickEnabled="True" />
+                        </toolkit:SettingsExpander.Items>
                     </toolkit:SettingsExpander>
                     <toolkit:SettingsCard x:Uid="LogFile" HeaderIcon="{ui:FontIcon Glyph=&#xE8E5;}">
                         <StackPanel Orientation="Horizontal" Spacing="12">

--- a/TouchSenderTablet.GUI/Views/SettingsPage.xaml.cs
+++ b/TouchSenderTablet.GUI/Views/SettingsPage.xaml.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.UI.Xaml;
+﻿using System.Diagnostics;
+
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 
 using TouchSenderTablet.GUI.Helpers;
@@ -27,5 +29,23 @@ public sealed partial class SettingsPage : Page
         {
             ViewModel.SwitchThemeCommand.Execute(EnumHelper.GetEnum<ElementTheme>(selectedTheme));
         }
+    }
+
+    private void GitHubRepositorySettingsCard_Click(object sender, RoutedEventArgs e)
+    {
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = "https://github.com/voltaney/TouchSenderTablet",
+            UseShellExecute = true,
+        });
+    }
+
+    private void GitHubIssuesSettingsCard_Click(object sender, RoutedEventArgs e)
+    {
+        Process.Start(new ProcessStartInfo
+        {
+            FileName = "https://github.com/voltaney/TouchSenderTablet/issues",
+            UseShellExecute = true,
+        });
     }
 }


### PR DESCRIPTION
This pull request introduces new functionality to the settings page of the `TouchSenderTablet` application, including links to the GitHub repository and the issues page for reporting bugs or sending feedback. Additionally, it includes some minor refactoring.

New functionality:

* [`TouchSenderTablet.GUI/Strings/en-us/Resources.resw`](diffhunk://#diff-bd23ffc832b2a7aa439584c6a8514c1d4d5bc784ebd4d1c90fbfe29b7f296c6fR147-R152): Added new entries for "GitHub Repository" and "Report a bug or send feedback" in the English resources file.
* [`TouchSenderTablet.GUI/Strings/ja-jp/Resources.resw`](diffhunk://#diff-33c691e7c688f1cc91f1e1bdffe7185b0ad11de1a9d3abf18b723089d6dbcb32R147-R152): Added new entries for "GitHub Repository" and "Report a bug or send feedback" in the Japanese resources file.
* [`TouchSenderTablet.GUI/Views/SettingsPage.xaml`](diffhunk://#diff-41af8870e99c945a58e95a54dc9b5a0e10b9eb30860680fdf2744f9ea1bceee7R54-R67): Added new `SettingsCard` elements for GitHub repository and issues links.
* [`TouchSenderTablet.GUI/Views/SettingsPage.xaml.cs`](diffhunk://#diff-ed1815ede7f85e9f5f21de28eb6522d964c0fa8a86a395085228055634e0c481R33-R50): Implemented click event handlers for the new `SettingsCard` elements to open the GitHub repository and issues page in the default web browser.

Refactoring:

* [`TouchSenderTablet.GUI/Views/SettingsPage.xaml.cs`](diffhunk://#diff-ed1815ede7f85e9f5f21de28eb6522d964c0fa8a86a395085228055634e0c481L1-R3): Added `System.Diagnostics` using directive for process handling.
